### PR TITLE
Client Status Watching

### DIFF
--- a/rlel/Account.xaml
+++ b/rlel/Account.xaml
@@ -5,7 +5,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" Height="20" Width="250" MouseDoubleClick="UserControl_MouseDoubleClick" >
     <Grid>
-        <TextBlock Name="username" Width="250" VerticalAlignment="Center" Height="18" />
+        <TextBlock Name="username" Width="250" VerticalAlignment="Center" Height="18" ScrollViewer.VerticalScrollBarVisibility="Disabled" />
         <PasswordBox Name="password" Password="" Visibility="Hidden" Margin="138,-1,162,1" />
+        <Label Name="runningTQ" Content="TQ"  VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Height="18" Width="20" Padding="0" Visibility="Hidden"/>
+        <Label Name="runningSiSi" Content="SISI" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,25,0" Height="18" Padding="0" Visibility="Hidden"/>
     </Grid>
 </UserControl>

--- a/rlel/App.xaml
+++ b/rlel/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="rlel.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             Startup="AppOnStartup" Exit="AppOnExit">
     <Application.Resources>
          
     </Application.Resources>

--- a/rlel/App.xaml.cs
+++ b/rlel/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Linq;
+using System.Threading;
 using System.Windows;
 
 namespace rlel {
@@ -10,5 +11,47 @@ namespace rlel {
     /// Interaction logic for App.xaml
     /// </summary>
     public partial class App : Application {
+
+        /// <summary>The unique mutex name.</summary>
+        private const string UniqueMutexName = "{2E0604DE-AF17-4FD9-89F9-5762BD2030E8}";
+        private static SingleInstance singleInstance;
+
+        /// <summary>The app on startup.</summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The e.</param>
+        private void AppOnStartup (object sender, StartupEventArgs e) {
+            if (singleInstance == null) {
+                Guid guid = new Guid(UniqueMutexName);
+                singleInstance = new SingleInstance(guid);
+            }
+            if (singleInstance.IsFirstInstance) {
+                singleInstance.ArgumentsReceived += singleInstance_ArgumentsReceived;
+                singleInstance.ListenForArgumentsFromSuccessiveInstances( );
+
+                MainWindow mainView = new MainWindow();
+                mainView.Show();
+                mainView.addCommandLineArgs(Environment.GetCommandLineArgs( ));
+            }
+            else {
+                // Pass Arguments to first Instance
+                singleInstance.PassArgumentsToFirstInstance(Environment.GetCommandLineArgs( ));
+                // Terminate this instance.
+                this.Shutdown( );
+            }
+
+            return;
+        }
+
+        private void singleInstance_ArgumentsReceived (object sender, ArgumentsReceivedEventArgs e) {
+            Current.Dispatcher.BeginInvoke(
+                                (Action)(() => ((MainWindow)Current.MainWindow).addCommandLineArgs(e.Args)));
+        }
+
+
+        private void AppOnExit (object sender, ExitEventArgs e) {
+            // make sure the used mutex is not collected, otherwise another instance can start.
+            GC.KeepAlive(singleInstance);
+        }
+
     }
 }

--- a/rlel/MainWindow.xaml.cs
+++ b/rlel/MainWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace rlel {
             this.rjm.IV = Convert.FromBase64String(iv);
             this.tray = new System.Windows.Forms.NotifyIcon( );
             this.commandQueue = new Queue<string[]>( );
-            this.checkingUpdate = false;
+            this.checkingUpdate = true;
         }
 
         private void browse_Click(object sender, RoutedEventArgs e) {

--- a/rlel/MainWindow.xaml.cs
+++ b/rlel/MainWindow.xaml.cs
@@ -26,6 +26,8 @@ namespace rlel {
         RijndaelManaged rjm = new RijndaelManaged();
         Thread tqpatching;
         Thread sisipatching;
+        bool checkingUpdate;
+        Queue<String[]> commandQueue;
 
         public MainWindow() {
             this.settings_upgrade();
@@ -34,6 +36,9 @@ namespace rlel {
             string iv = this.getIV();
             this.rjm.Key = Convert.FromBase64String(key);
             this.rjm.IV = Convert.FromBase64String(iv);
+            this.tray = new System.Windows.Forms.NotifyIcon( );
+            this.commandQueue = new Queue<string[]>( );
+            this.checkingUpdate = false;
         }
 
         private void browse_Click(object sender, RoutedEventArgs e) {
@@ -79,7 +84,7 @@ namespace rlel {
             update_check.SetApartmentState(ApartmentState.STA);
             update_check.Start();
             this.evePath.Text = Properties.Settings.Default.TranqPath;
-            this.tray = new System.Windows.Forms.NotifyIcon();
+            
             this.tray.Icon = System.Drawing.Icon.ExtractAssociatedIcon(Application.ResourceAssembly.Location);
             this.tray.Text = this.Title;
             this.tray.ContextMenu = new System.Windows.Forms.ContextMenu();
@@ -289,6 +294,7 @@ namespace rlel {
         }
 
         private void checkClientVersion() {
+            this.checkingUpdate = true;
             this.updateEveVersion();
             StreamReader sr;
             int clientVers;
@@ -310,6 +316,12 @@ namespace rlel {
                     this.patch(Properties.Settings.Default.SisiPath, true);
                 }
                 sr.Close();
+            }
+            this.checkingUpdate = false;
+            if (this.commandQueue.Count > 0)
+            {
+                App.Current.Dispatcher.BeginInvoke(
+                    (Action)(() => ((MainWindow)App.Current.MainWindow).handleCommandLineArgs( )));
             }
         }
 
@@ -468,7 +480,8 @@ namespace rlel {
 
         private void launch_Click(object sender, RoutedEventArgs e) {
             foreach (Account acct in this.accountsPanel.SelectedItems) {
-                acct.launchAccount();
+                if (!acct.ClientIsRunning())
+                    acct.launchAccount();
             }
         }
 
@@ -501,6 +514,72 @@ namespace rlel {
             if (localversion < remoteversion) {
                 update u = new update();
                 u.ShowDialog();
+            }
+        }
+
+        /// <summary>Brings main window to foreground.</summary>
+        public void bringToForeground () {
+            if (this.WindowState == WindowState.Minimized || this.Visibility == Visibility.Hidden) {
+                this.Show( );
+                this.WindowState = WindowState.Normal;
+            }
+
+            // According to some sources these steps gurantee that an app will be brought to foreground.
+            this.Activate( );
+            this.Topmost = true;
+            this.Topmost = false;
+            this.Focus( );
+        }
+
+        public void addCommandLineArgs (string[] args) {
+            bringToForeground( );
+            this.commandQueue.Enqueue(args);
+            if (!this.checkingUpdate)
+                handleCommandLineArgs();
+
+
+        }
+        private void handleCommandLineArgs(){
+            while (commandQueue.Count > 0) {
+                string[] args = commandQueue.Dequeue( );
+
+                // first value in args is executing file path
+                if (args != null && args.Length > 1) {
+                    string lastCommand = string.Empty;
+                    for (int i = 1; i < args.Length; i++) {
+                        if (string.IsNullOrEmpty(args[i]))
+                            continue;
+                        switch (args[i].ToLower()) {
+                            case "-tq":
+                                this.singularity.IsChecked = false;
+                                singularity_Click(this, new RoutedEventArgs( ));
+                                lastCommand = string.Empty;
+                                break;
+                            case "-sisi":
+                                this.singularity.IsChecked = true;
+                                singularity_Click(this, new RoutedEventArgs( ));
+                                lastCommand = string.Empty;
+                                break;
+                            case "-l":
+                            case "--launch":
+                                lastCommand = "launch";
+                                break;
+                            default:
+                                // handling of command parameters
+                                switch (lastCommand) {
+                                    case "launch":
+                                        foreach (Account account in this.accountsPanel.Items) {
+                                            if (account.username.Text.ToLower( ) == args[i].ToLower( )) {
+                                                account.activateAccount( );
+                                                break;
+                                            }
+                                        }
+                                        break;
+                                }
+                                break;
+                        }
+                    }
+                }
             }
         }
     }

--- a/rlel/MainWindow.xaml.cs
+++ b/rlel/MainWindow.xaml.cs
@@ -532,11 +532,13 @@ namespace rlel {
         }
 
         public void addCommandLineArgs (string[] args) {
-            bringToForeground( );
-            this.commandQueue.Enqueue(args);
-            if (!this.checkingUpdate)
-                handleCommandLineArgs();
-
+            if (args.Length > 1 && args[1] != null) {
+                this.commandQueue.Enqueue(args);
+                if (!this.checkingUpdate)
+                    handleCommandLineArgs();
+            }
+            else
+                bringToForeground( );
 
         }
         private void handleCommandLineArgs(){

--- a/rlel/SingleInstance.cs
+++ b/rlel/SingleInstance.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Collections.Generic;
+
+namespace rlel
+{
+    /// <summary>
+    /// Holds a list of arguments given to an application at startup.
+    /// </summary>
+    public class ArgumentsReceivedEventArgs : EventArgs {
+        public String[] Args {
+            get;
+            set;
+        }
+    }
+
+    /// <summary>
+    /// Enforces single instance for an application.
+    /// </summary>
+    public class SingleInstance : IDisposable {
+        private Mutex mutex = null;
+        private Boolean ownsMutex = false;
+        private Guid identifier = Guid.Empty;
+
+        /// <summary>
+        /// Enforces single instance for an application.
+        /// </summary>
+        /// <param name="identifier">An identifier unique to this application.</param>
+        public SingleInstance(Guid identifier) {
+            this.identifier = identifier;
+
+            if (mutex == null)
+                mutex = new Mutex(true, identifier.ToString( ), out ownsMutex);
+            else
+                throw new InvalidOperationException("Only one mutex Instance is supported");
+        }
+
+        /// <summary>
+        /// Indicates whether this is the first instance of this application.
+        /// </summary>
+        public Boolean IsFirstInstance { get { return ownsMutex; } }
+
+        /// <summary>
+        /// Passes the given arguments to the first running instance of the application.
+        /// </summary>
+        /// <param name="arguments">The arguments to pass.</param>
+        /// <returns>Return true if the operation succeded, false otherwise.</returns>
+        public Boolean PassArgumentsToFirstInstance(String[] arguments) {
+            if (IsFirstInstance)
+                throw new InvalidOperationException("This is the first instance.");
+
+            try {
+                using (NamedPipeClientStream client = new NamedPipeClientStream(identifier.ToString()))
+                using (StreamWriter writer = new StreamWriter(client)) {
+                    client.Connect(200);
+
+                    foreach (String argument in arguments)
+                        writer.WriteLine(argument);
+                }
+                return true;
+            }
+            catch (TimeoutException) { } //Couldn't connect to server
+            catch (IOException) { } //Pipe was broken
+
+            return false;
+        }
+
+        /// <summary>
+        /// Listens for arguments being passed from successive instances of the applicaiton.
+        /// </summary>
+        public void ListenForArgumentsFromSuccessiveInstances() {
+            if (!IsFirstInstance)
+                throw new InvalidOperationException("This is not the first instance.");
+            ThreadPool.QueueUserWorkItem(new WaitCallback(ListenForArguments));
+        }
+
+        /// <summary>
+        /// Listens for arguments on a named pipe.
+        /// </summary>
+        /// <param name="state">State object required by WaitCallback delegate.</param>
+        private void ListenForArguments(Object state) {
+            try {
+                using (NamedPipeServerStream server = new NamedPipeServerStream(identifier.ToString( )))
+                using (StreamReader reader = new StreamReader(server))
+                {
+                    server.WaitForConnection( );
+
+                    List<String> arguments = new List<String>( );
+                    while (server.IsConnected)
+                        arguments.Add(reader.ReadLine( ));
+
+                    ThreadPool.QueueUserWorkItem(new WaitCallback(CallOnArgumentsReceived), arguments.ToArray( ));
+                }
+            }
+            catch (IOException) { } //Pipe was broken
+
+            finally {
+                ListenForArguments(null);
+            }
+        }
+
+        /// <summary>
+        /// Calls the OnArgumentsReceived method casting the state Object to String[].
+        /// </summary>
+        /// <param name="state">The arguments to pass.</param>
+        private void CallOnArgumentsReceived(Object state) {
+            OnArgumentsReceived((String[])state);
+        }
+        /// <summary>
+        /// Event raised when arguments are received from successive instances.
+        /// </summary>
+        public event EventHandler<ArgumentsReceivedEventArgs> ArgumentsReceived;
+        /// <summary>
+        /// Fires the ArgumentsReceived event.
+        /// </summary>
+        /// <param name="arguments">The arguments to pass with the ArgumentsReceivedEventArgs.</param>
+        private void OnArgumentsReceived(String[] arguments) {
+            if (ArgumentsReceived != null)
+                ArgumentsReceived(this, new ArgumentsReceivedEventArgs() { Args = arguments });
+        }
+
+        #region IDisposable
+        private Boolean disposed = false;
+
+        protected virtual void Dispose(bool disposing) {
+            if (!disposed) {
+                if (mutex != null && ownsMutex) {
+                    mutex.ReleaseMutex();
+                    mutex = null;
+                }
+                disposed = true;
+            }
+        }
+
+        ~SingleInstance() {
+            Dispose(false);
+        }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/rlel/rlel.csproj
+++ b/rlel/rlel.csproj
@@ -95,6 +95,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Settings.cs" />
+    <Compile Include="SingleInstance.cs" />
     <Compile Include="update.xaml.cs">
       <DependentUpon>update.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Added a simple solution to see in the launcher which clients are running.
Its keeping track of the exefile process, so it only if account is started from the launcher.

[ x ] Remembering the launched Client processes, and displaying there status.
[ x ] Bringing active client to foreground and setting focus.
[ x ] Only single application instance possible. To ensure the clients are tracked.
[ x ] New rlel instances signals first instance and brings it to foreground.
[ x ] Command line args are send to first instance
[ x ] Acting on command line args, like launching account or making its window active
